### PR TITLE
refactor: contextMenus 권한 제거 및 문서 정리

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,11 @@
       "Bash(mv:*)",
       "Bash(rm:*)",
       "Bash(gh pr create:*)",
-      "WebFetch(domain:support.google.com)"
+      "WebFetch(domain:support.google.com)",
+      "Bash(gh pr:*)",
+      "Bash(git merge:*)",
+      "Bash(git fetch:*)",
+      "Bash(git rm:*)"
     ],
     "deny": []
   }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 
 ### 🆕 Chrome Side Panel API (v2.0)
 - **네이티브 사이드 패널**: Chrome 공식 Side Panel API 사용으로 안정성과 성능 향상
-- **우클릭 메뉴**: 컨텍스트 메뉴로 빠른 장소 저장
 - **시스템 알림**: Chrome 알림 API로 작업 완료 알림
 - **원클릭 접근**: 툴바 아이콘 클릭으로 즉시 패널 열기/닫기
 
@@ -73,7 +72,6 @@
 
 ### 2️⃣ Side Panel 열기
 - **툴바 아이콘 클릭**: CustomPlaceDB 아이콘을 한 번 클릭하면 Side Panel이 열림
-- **우클릭 메뉴**: 지도 페이지에서 우클릭 → '현재 장소 저장하기'
 
 ### 3️⃣ 장소 선택 및 저장
 - **Side Panel 버튼**: 지도에서 장소를 선택한 후 Side Panel에서 '현재 보고 있는 장소 추가' 클릭
@@ -131,7 +129,6 @@ Side Panel에서 '새 목록 생성' 또는 기존 목록 선택하여 체계적
 ### Chrome APIs
 - **Chrome Storage API** - 로컬 데이터 저장
 - **Chrome Notifications API** - 시스템 알림
-- **Chrome Context Menus API** - 우클릭 메뉴
 - **Chrome Tabs API** - 탭 관리
 
 ### Frontend
@@ -144,7 +141,7 @@ Side Panel에서 '새 목록 생성' 또는 기존 목록 선택하여 체계적
 
 - **총 코드 라인**: 4,500+ 라인 (v2.0 업데이트 포함)
 - **지원 플랫폼**: 2개 (네이버지도, 카카오맵)
-- **Chrome API 활용**: 5개 (sidePanel, storage, notifications, contextMenus, activeTab)
+- **Chrome API 활용**: 4개 (sidePanel, storage, notifications, activeTab)
 - **개발 기간**: 8일 (7/10 ~ 7/14 + 7/30 + 8/7)
 - **핵심 작업**
   - 단순 스크랩 → 커스텀 데이터베이스 시스템
@@ -165,7 +162,6 @@ Side Panel에서 '새 목록 생성' 또는 기존 목록 선택하여 체계적
   - 네이티브 브라우저 Side Panel로 안정성과 성능 대폭 향상
   - 툴바 아이콘 클릭으로 패널 열기/닫기 원터치 지원
   - 브라우저 창 크기에 관계없이 일정한 패널 영역 확보
-- 🖱️ **우클릭 컨텍스트 메뉴**: 지도 페이지에서 우클릭으로 빠른 장소 저장
 - 🗑️ **단축키 기능 제거**: 사용성이 낮고 다른 기능과 충돌 가능성이 있는 키보드 단축키 관련 코드를 모두 제거하여 기능을 단순화했습니다.
 - 🔔 **시스템 알림**: Chrome Notifications API로 작업 완료 피드백
 - 🎨 **커스텀 테마 시스템**: 5가지 기본 테마 + 사용자 정의 테마 생성 기능

--- a/background.js
+++ b/background.js
@@ -25,9 +25,6 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.sidePanel
     .setPanelBehavior({ openPanelOnActionClick: true })
     .catch((error) => console.error(error));
-  
-  // 컨텍스트 메뉴 생성
-  createContextMenus();
 });
 
 // ==================== Side Panel 관리 ====================
@@ -71,42 +68,6 @@ async function savePlaceFromTab(tab) {
     return { success: false, error: error.message };
   }
 }
-
-
-// ==================== 컨텍스트 메뉴 관리 ====================
-function createContextMenus() {
-  chrome.contextMenus.create({
-    id: 'save-current-place',
-    title: '현재 장소 저장하기',
-    contexts: ['page'],
-    documentUrlPatterns: [
-      'https://map.naver.com/*',
-      'https://map.kakao.com/*',
-      'https://place.map.kakao.com/*'
-    ]
-  });
-  
-  chrome.contextMenus.create({
-    id: 'open-settings',
-    title: '설정 열기',
-    contexts: ['action']
-  });
-}
-
-chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-  if (info.menuItemId === 'save-current-place') {
-    await savePlaceFromTab(tab);
-  } else if (info.menuItemId === 'open-settings') {
-    // 설정 창 열기
-    chrome.windows.create({
-      url: chrome.runtime.getURL('popup.html'),
-      type: 'popup',
-      width: 350,
-      height: 600,
-      focused: true
-    });
-  }
-});
 
 // ==================== 알림 관리 ====================
 function showNotification(message, type = 'info') {

--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,7 @@
     "storage",
     "activeTab",
     "sidePanel",
-    "notifications",
-    "contextMenus"
+    "notifications"
   ],
   "host_permissions": [
     "https://map.naver.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
   "host_permissions": [
     "https://map.naver.com/*",
     "https://pcmap.place.naver.com/*",
-    "https://map.kakao.com/*"
+    "https://map.kakao.com/*",
+    "https://place.map.kakao.com/*"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
- contextMenus 권한 및 우클릭 메뉴 기능 완전 제거
- 관련 문서 정리 및 호스트 권한 수정
- 키보드 단축키 기능 제거로 기능 단순화

## 변경사항
### 🗑️ contextMenus 제거
- manifest.json에서 contextMenus 권한 제거
- background.js에서 우클릭 메뉴 관련 코드 제거
- README.md에서 우클릭 메뉴 설명 모두 제거

### 📝 문서 업데이트
- Chrome API 활용 개수를 5개에서 4개로 수정
- 우클릭 메뉴 관련 사용법 설명 제거
- v2.0 기능 설명에서 contextMenus 언급 제거

### 🔧 권한 수정
- manifest.json에 place.map.kakao.com 호스트 권한 추가
- 카카오맵 장소 상세 페이지 지원 개선

## Test Plan
- [ ] 우클릭 시 커스텀 메뉴가 나타나지 않는지 확인
- [ ] 카카오맵 place.map.kakao.com에서 정상 작동 확인
- [ ] Side Panel을 통한 장소 저장 기능만 사용 가능한지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)